### PR TITLE
add cloudformation to create the data bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4]
+
+### Added
+* Automated creation of the S3 data bucket.
+
 ## [0.0.3]
 
 ### Added 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Sentinel-1 Orbits
 
-Lambda Function and API for the retrieval of Sentinel-1 orbits, from Copernicus, for storage in AWS S3.
+Applications supporting the [Sentinel-1 Precise Orbit Determination (POD) products]()
+data set in the Registry of Open Data on AWS.

--- a/apps/bucket/cloudformation.yml
+++ b/apps/bucket/cloudformation.yml
@@ -1,0 +1,117 @@
+# adapted from https://s3-us-west-2.amazonaws.com/opendata.aws/pds-bucket-cf.yml
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: This template creates the AWS infrastructure to publish a public data set on S3. It creates a publicly-accessible S3 bucket for the dataset, enables CloudWatch Metrics for the dataset bucket, and creates a public SQS and Lambda subscribable SNS Topic.
+
+Parameters:
+  DataSetName:
+    AllowedPattern: "[a-z0-9\\.\\-]*"
+    ConstraintDescription: may only contain lowercase letters, numbers, and ., or - characters
+    Description: "The name of the dataset's S3 bucket. This will be used to create the dataset S3 bucket."
+    MaxLength: '250'
+    MinLength: '1'
+    Type: String
+
+Resources:
+  SNSTopic:
+    Properties:
+      TopicName: !Join [ "", [ !Join [ "", !Split [ ".", !Ref DataSetName ] ], "-object_created" ] ]
+    Type: AWS::SNS::Topic
+  SNSTopicPolicy:
+    Properties:
+      Topics:
+        - !Ref SNSTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: allowS3BucketToPublish
+          Effect: Allow
+          Action:
+            - sns:Publish
+          Resource: !Ref SNSTopic
+          Principal:
+            Service: s3.amazonaws.com
+          Condition:
+            ArnLike:
+              aws:SourceArn: !Sub arn:aws:s3:::${DataSetName}
+        - Sid: allowOnlySQSandLambdaSubscription
+          Effect: Allow
+          Action:
+            - sns:Subscribe
+            - sns:Receive
+          Resource: !Ref SNSTopic
+          Principal:
+            AWS: "*"
+          Condition:
+            StringEquals:
+              SNS:Protocol:
+                - sqs
+                - lambda
+    Type: AWS::SNS::TopicPolicy
+  DataSetBucket:
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Delete
+    DependsOn:
+      - SNSTopicPolicy
+    Properties:
+      BucketName: !Ref DataSetName
+      MetricsConfigurations:
+        - Id: EntireBucket
+      LifecycleConfiguration:
+        Rules:
+        - Id: IntelligentTieringRule
+          Status: Enabled
+          Transitions:
+            - TransitionInDays: '0'
+              StorageClass: INTELLIGENT_TIERING
+        - Id: AbortIncompleteMultipartUploadRule
+          Status: Enabled
+          AbortIncompleteMultipartUpload:
+            DaysAfterInitiation: 7
+        - Id: ExpireResorb
+          Status: Enabled
+          Prefix: AUX_RESORB/
+          ExpirationInDays: 91
+      NotificationConfiguration:
+        TopicConfigurations:
+        - Event: "s3:ObjectCreated:*"
+          Topic: !Ref SNSTopic
+      PublicAccessBlockConfiguration:
+          BlockPublicPolicy: false
+          RestrictPublicBuckets: false
+      CorsConfiguration:
+        CorsRules:
+        - AllowedHeaders:
+            - "*"
+          AllowedMethods:
+            - HEAD
+            - GET
+          AllowedOrigins:
+            - "*"
+          ExposedHeaders:
+            - ETag
+            - x-amz-meta-custom-header
+          MaxAge: 3000
+    Type: AWS::S3::Bucket
+  DataSetBucketPolicy:
+    Properties:
+      Bucket: !Ref DataSetBucket
+      PolicyDocument:
+        Statement:
+        - Action:
+          - s3:List*
+          - s3:Get*
+          Effect: Allow
+          Principal: "*"
+          Resource:
+          - !Sub arn:aws:s3:::${DataSetBucket}/*
+          - !Sub arn:aws:s3:::${DataSetBucket}
+    Type: AWS::S3::BucketPolicy
+
+Outputs:
+  DataBucket:
+    Description: "S3 data bucket name"
+    Value: !Sub ${DataSetBucket}
+  SNSTopic:
+    Description: "SQS and Lambda subscribable SNS Topic"
+    Value: !Ref SNSTopic

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -13,18 +13,25 @@ Parameters:
 
 Resources:
 
+  Bucket:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        DataSetName: !Ref BucketName
+      TemplateURL: apps/bucket/cloudformation.yml
+
   Api:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
-        BucketName: !Ref BucketName
+        BucketName: !GetAtt Bucket.Outputs.DataBucket
       TemplateURL: apps/api/cloudformation.yml
 
   Fetcher:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
-        BucketName: !Ref BucketName
+        BucketName: !GetAtt Bucket.Outputs.DataBucket
         CdseUsername: !Ref CdseUsername
         CdsePassword: !Ref CdsePassword
       TemplateURL: apps/fetcher/cloudformation.yml


### PR DESCRIPTION
cloudformation template is adapted from https://s3-us-west-2.amazonaws.com/opendata.aws/pds-bucket-cf.yml ; only change was to add a lifecycle policy for AUX_RESORB files.

For more information, see the [Onboarding Handbook for Data Providers](https://assets.opendata.aws/aws-onboarding-handbook-for-data-providers.pdf), Chapter 5