### PR TITLE
Fix Bucket Policy Syntax Error

### DIFF
--- a/apps/bucket/cloudformation.yml
+++ b/apps/bucket/cloudformation.yml
@@ -81,7 +81,7 @@ Resources:
     Properties:
       Bucket: !Ref LogBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -161,6 +161,7 @@ Resources:
         Statement:
         - Action: s3:PutObject
           Effect: Allow
-          Principal: !Sub arn:aws:iam::${AwsApplicationAccountId}:role/${FetcherRoleName}
+          Principal:
+            AWS: !Sub arn:aws:iam::${AwsApplicationAccountId}:role/${FetcherRoleName}
           Resource: !Sub arn:aws:s3:::${DataSetBucket}/*
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
The principal needs AWS in front. Versions should also have quotes.