### PR TITLE
Give root Access to S3 Bucket Rather Than Named Role

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -34,8 +34,6 @@ inputs:
     required: true
   CDSE_PASSWORD:
     required: true
-  FETCHER_ROLE_NAME:
-    required: true
 
 runs:
   using: composite
@@ -60,8 +58,7 @@ runs:
           --role-arn ${{ inputs.OPENDATA_CLOUDFORMATION_ROLE_ARN }} \
           --parameter-overrides \
               BucketName='${{ inputs.BUCKET_NAME }}' \
-              AwsApplicationAccountId='${{ inputs.AWS_APPLICATION_ACCOUNT_ID }}' \
-              FetcherRoleName='${{ inputs.FETCHER_ROLE_NAME }}'
+              AwsApplicationAccountId='${{ inputs.AWS_APPLICATION_ACCOUNT_ID }}'
 
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -91,11 +88,10 @@ runs:
           --stack-name ${{ inputs.APP_STACK_NAME }} \
           --template-file app_packaged.yml \
           --role-arn ${{ inputs.CLOUDFORMATION_ROLE_ARN }} \
-          --capabilities CAPABILITY_NAMED_IAM \
+          --capabilities CAPABILITY_IAM \
           --parameter-overrides \
               BucketName='${{ inputs.BUCKET_NAME }}' \
               DomainName='${{ inputs.DOMAIN_NAME }}' \
               CertificateArn='${{ inputs.CERTIFICATE_ARN }}' \
               CdseUsername='${{ inputs.CDSE_USERNAME }}' \
-              CdsePassword='${{ inputs.CDSE_PASSWORD }}' \
-              FetcherRoleName='${{ inputs.FETCHER_ROLE_NAME }}'
+              CdsePassword='${{ inputs.CDSE_PASSWORD }}'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -6,10 +6,6 @@ on:
       - main
   workflow_dispatch:
     inputs:
-      FETCHER_ROLE_NAME:
-        type: string
-        description: The name to give to the IAM role that the fetcher uses.
-        default: orbits-fetcher
       APPLICATION_STACK_NAME:
         type: string
         description: The name to give to the application stack.
@@ -54,6 +50,5 @@ jobs:
           APP_STACK_NAME: ${{ github.event.inputs.APPLICATION_STACK_NAME || 's1-orbits' }}
           BUCKET_NAME: ${{ github.event.inputs.BUCKET_NAME || 's1-orbits' }}
           DOMAIN_NAME: ${{ github.event.inputs.DOMAIN_NAME || 's1-orbits.asf.alaska.edu' }}
-          FETCHER_ROLE_NAME: ${{ github.event.inputs.FETCHER_ROLE_NAME || 'orbits-fetcher' }}
           OPENDATA_TEMPLATE_BUCKET: cf-templates-250jrbt1c7xh-us-west-2
           TEMPLATE_BUCKET: cf-templates-aubvn3i9olmk-us-west-2

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -6,10 +6,6 @@ on:
       - develop
   workflow_dispatch:
     inputs:
-      FETCHER_ROLE_NAME:
-        type: string
-        description: The name to give to the IAM role that the fetcher uses.
-        default: orbits-test-fetcher
       APPLICATION_STACK_NAME:
         type: string
         description: The name to give to the application stack.
@@ -54,6 +50,5 @@ jobs:
           APP_STACK_NAME: ${{ github.event.inputs.APPLICATION_STACK_NAME || 's1-orbits-test' }}
           BUCKET_NAME: ${{ github.event.inputs.BUCKET_NAME || 's1-orbits-test' }}
           DOMAIN_NAME: ${{ github.event.inputs.DOMAIN_NAME || 's1-orbits-test.asf.alaska.edu' }}
-          FETCHER_ROLE_NAME: ${{ github.event.inputs.FETCHER_ROLE_NAME || 'orbits-test-fetcher' }}
           OPENDATA_TEMPLATE_BUCKET: cf-templates-aubvn3i9olmk-us-west-2
           TEMPLATE_BUCKET: cf-templates-aubvn3i9olmk-us-west-2

--- a/apps/bucket/cloudformation.yml
+++ b/apps/bucket/cloudformation.yml
@@ -13,9 +13,6 @@ Parameters:
   AwsApplicationAccountId:
     Type: String
 
-  FetcherRoleName:
-    Type: String
-
 Resources:
   SNSTopic:
     Properties:
@@ -162,6 +159,6 @@ Resources:
         - Action: s3:PutObject
           Effect: Allow
           Principal:
-            AWS: !Sub arn:aws:iam::${AwsApplicationAccountId}:role/${FetcherRoleName}
+            AWS: !Sub arn:aws:iam::${AwsApplicationAccountId}:root
           Resource: !Sub arn:aws:s3:::${DataSetBucket}/*
     Type: AWS::S3::BucketPolicy

--- a/apps/bucket/cloudformation.yml
+++ b/apps/bucket/cloudformation.yml
@@ -159,6 +159,6 @@ Resources:
         - Action: s3:PutObject
           Effect: Allow
           Principal:
-            AWS: !Sub arn:aws:iam::${AwsApplicationAccountId}:root
+            AWS: !Ref AwsApplicationAccountId
           Resource: !Sub arn:aws:s3:::${DataSetBucket}/*
     Type: AWS::S3::BucketPolicy

--- a/apps/fetcher/cloudformation.yml
+++ b/apps/fetcher/cloudformation.yml
@@ -13,9 +13,6 @@ Parameters:
     Type: String
     NoEcho: true
 
-  FetcherRoleName:
-    Type: String
-
 Resources:
   Secret:
     Type: AWS::SecretsManager::Secret
@@ -41,7 +38,6 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      RoleName: !Ref FetcherRoleName
 
   Policy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
The S3 bucket policy will not create if the principal does not exist yet.