### PR TITLE
fix read permissions for content bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+
+### Fixed
+* Public read permissions were not correctly applied to the data bucket in v0.1.0.
+
 ## [0.1.0]
 
+### Changed
 * The bucket stack has been separated from the application stack for deployment into a separate account.
 
 ## [0.0.5]
 
+### Added
 * Automated creation of a log bucket for the data bucket.
 
 ## [0.0.4]

--- a/apps/bucket/cloudformation.yml
+++ b/apps/bucket/cloudformation.yml
@@ -155,7 +155,6 @@ Resources:
           Resource:
           - !Sub arn:aws:s3:::${DataSetBucket}/*
           - !Sub arn:aws:s3:::${DataSetBucket}
-        Statement:
         - Action: s3:PutObject
           Effect: Allow
           Principal:


### PR DESCRIPTION
`Statement` is a list of statements; having two `Statement` fields resulted in only the second one being applied